### PR TITLE
Add 2 to MAX_SANDBOXES when comparing for count

### DIFF
--- a/sandbox_manager/lib/SandboxManager/Controller/Sandboxes.pm
+++ b/sandbox_manager/lib/SandboxManager/Controller/Sandboxes.pm
@@ -371,7 +371,9 @@ sub max_sandboxes_reached {
     my $count = () = readdir($dh);
     closedir($dh);
 
-    return $count >= $user_vars->{MAX_SANDBOXES};
+    # Add 2 to account for `.` and `..`
+    my $max = $user_vars->{MAX_SANDBOXES} + 2;
+    return $count >= $max;
 }
 
 1;


### PR DESCRIPTION
readdir lists `.` and `..` within the returned array and as such for
comparison it was always over counting.