### PR TITLE
Correct logic for when not to apply git remotes

### DIFF
--- a/ansible/create-sandbox-instance.yml
+++ b/ansible/create-sandbox-instance.yml
@@ -176,7 +176,7 @@
     - name: "Add git remote {{ GIT_REMOTE }} as {{ KOHA_INSTANCE }} and checkout {{ GIT_BRANCH }}"
       delegate_to: "koha-{{ KOHA_INSTANCE }}"
       shell: "cd /kohadevbox/koha && git remote add {{ KOHA_INSTANCE }} {{ GIT_REMOTE }} && git fetch {{ KOHA_INSTANCE }} && git checkout {{ KOHA_INSTANCE }}/{{ GIT_BRANCH }}"
-      when: not( (GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == '') and not(GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == '') )
+      when: not( (GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == '')) and not( (GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == '') )
       ignore_errors: yes
       notify:
         - "Restart plack in docker container"
@@ -185,7 +185,7 @@
     - name: "Checkout origin/master in docker container"
       delegate_to: "koha-{{ KOHA_INSTANCE }}"
       shell: "cd /kohadevbox/koha && yes | git checkout origin/master"
-      when: ((GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == '')) and ((GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == ''))
+      when: ((GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == '')) or ((GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == ''))
       ignore_errors: no
       notify:
         - "Restart plack in docker container"


### PR DESCRIPTION
The 'when' logic was incorrect for actioning the git remote handling.
This patch corrects that logic and allows bug application to work as
expected again.