### PR TITLE
Add mail logger

### DIFF
--- a/ansible/create-sandbox-instance.yml
+++ b/ansible/create-sandbox-instance.yml
@@ -220,6 +220,17 @@
         name: root
         password: "{{ KOHA_SSH_PASSWORD | password_hash('sha512') }}"
 
+    - name: "Install Postfix MTA"
+      delegate_to: "koha-{{ KOHA_INSTANCE }}"
+      apt:
+        name: postfix
+        update_cache: yes
+        state: present
+      ignore_errors: yes
+    - name: "Enable smtp-sink for mail"
+      delegate_to: "koha-{{ KOHA_INSTANCE }}"
+      shell: "smtp-sink -u root -D mail 127.0.0.1:25 100"
+
     - name: "Index the records for the first time"
       delegate_to: "koha-{{ KOHA_INSTANCE }}"
       shell: "koha-rebuild-zebra -f -a -b -v {{ KOHA_INSTANCE }}"

--- a/sandbox_manager/lib/SandboxManager.pm
+++ b/sandbox_manager/lib/SandboxManager.pm
@@ -35,6 +35,7 @@ sub startup {
     $r->any('/docker_log/:name')->to('sandboxes#docker_log');
     $r->any('/koha_log/:name/:file')->to('sandboxes#koha_log');
     $r->any('/git_log/:name')->to('sandboxes#git_log');
+    $r->any('/mail_log/:name')->to('sandboxes#mail_log');
     $r->any('/delete/:name')->to('sandboxes#delete');
     $r->any('/restart_all/:name')->to('sandboxes#restart_all');
     $r->any('/reindex_full/:name')->to('sandboxes#reindex_full');

--- a/sandbox_manager/lib/SandboxManager/Controller/Sandboxes.pm
+++ b/sandbox_manager/lib/SandboxManager/Controller/Sandboxes.pm
@@ -397,6 +397,17 @@ sub git_log {
     $self->render( title => "Koha git log", text => $text, format => 'txt' );
 }
 
+sub mail_log {
+    my $self = shift;
+    my $name = $self->stash('name');
+
+    $self->redirect_to('/') unless -f "$config_dir/$name.yml";
+
+    my $text = qx{ docker exec koha-$name bash -c "cat /root/mail" };
+
+    $self->render( title => "Koha mail log", text => $text, format => 'txt' );
+}
+
 sub max_sandboxes_reached {
     opendir( my $dh, $config_dir );
     my $count = () = readdir($dh);

--- a/sandbox_manager/templates/sandboxes/list.html.tt2
+++ b/sandbox_manager/templates/sandboxes/list.html.tt2
@@ -47,6 +47,7 @@
                             <a class="dropdown-item" target="_blank" href="/koha_log/[% s.KOHA_INSTANCE | html %]/plack"><i class="fas fa-file-alt"></i> Koha Plack log</a>
                             <a class="dropdown-item" target="_blank" href="/koha_log/[% s.KOHA_INSTANCE | html %]/intranet-error"><i class="fas fa-file-alt"></i> Koha Apache intranet error log</a>
                             <a class="dropdown-item" target="_blank" href="/koha_log/[% s.KOHA_INSTANCE | html %]/opac-error"><i class="fas fa-file-alt"></i> Koha Apache OPAC error log</a>
+                            <a class="dropdown-item" target="_blank" href="/mail_log/[% s.KOHA_INSTANCE | html %]"><i class="fas fa-file-alt"></i> Koha Mail log</a>
                             <div class="dropdown-divider"></div>
                             <a class="dropdown-item" target="_blank" href="/git_log/[% s.KOHA_INSTANCE | html %]"><i class="fas fa-file-alt"></i> Koha Git log</a>
                         </div>


### PR DESCRIPTION
This pull request adds a mail transfer agent using the postfix smtp-sink system and then exposes the sent messages via a new `Koha Mail log` option under the sandbox UI 'Logs' menu.