### PR TITLE
Issue #9 - Add the ability to provide a commit id or a tag name

### DIFF
--- a/ansible/create-sandbox-instance.yml
+++ b/ansible/create-sandbox-instance.yml
@@ -173,10 +173,25 @@
         ansible_connection: docker
       changed_when: false
 
-    - name: "Add git remote {{ GIT_REMOTE }} as {{ KOHA_INSTANCE }} and checkout {{ GIT_BRANCH }}"
+    - name: "Add git remote {{ GIT_REMOTE }} as {{ KOHA_INSTANCE }} in docker container"
       delegate_to: "koha-{{ KOHA_INSTANCE }}"
-      shell: "cd /kohadevbox/koha && git remote add {{ KOHA_INSTANCE }} {{ GIT_REMOTE }} && git fetch {{ KOHA_INSTANCE }} && git checkout {{ KOHA_INSTANCE }}/{{ GIT_BRANCH }}"
-      when: not( (GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == '')) and not( (GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == '') )
+      shell: "cd /kohadevbox/koha && git remote add {{ KOHA_INSTANCE }} {{ GIT_REMOTE }} && git fetch {{ KOHA_INSTANCE }}"
+      when: not( (GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == ''))
+      ignore_errors: yes
+
+    - name: "git checkout commit_id or tag {{ GIT_COMMITID }} in docker container"
+      delegate_to: "koha-{{ KOHA_INSTANCE }}"
+      shell: "cd /kohadevbox/koha && git checkout {{ GIT_COMMITID }}"
+      when: not( (GIT_COMMITID is undefined) or (GIT_COMMITID is none) or (GIT_COMMITID | trim == '') )
+      ignore_errors: yes
+      notify:
+        - "Restart plack in docker container"
+        - "Run updatedatabase.pl in docker container"
+
+    - name: "git checkout {{ KOHA_INSTANCE }}/{{ GIT_BRANCH }} in docker container"
+      delegate_to: "koha-{{ KOHA_INSTANCE }}"
+      shell: "cd /kohadevbox/koha && git checkout {{KOHA_INSTANCE}}/{{ GIT_BRANCH }}"
+      when: not( (GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == '') )
       ignore_errors: yes
       notify:
         - "Restart plack in docker container"
@@ -184,8 +199,8 @@
 
     - name: "Checkout origin/master in docker container"
       delegate_to: "koha-{{ KOHA_INSTANCE }}"
-      shell: "cd /kohadevbox/koha && yes | git checkout origin/master"
-      when: ((GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == '')) or ((GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == ''))
+      shell: "cd /kohadevbox/koha && git checkout origin/master"
+      when: ((GIT_REMOTE is undefined) or (GIT_REMOTE is none) or (GIT_REMOTE | trim == '')) and ((GIT_BRANCH is undefined) or (GIT_BRANCH is none) or (GIT_BRANCH | trim == '')) and ((GIT_COMMITID is undefined) or (GIT_COMMITID is none) or (GIT_COMMITID | trim == ''))
       ignore_errors: no
       notify:
         - "Restart plack in docker container"

--- a/sandbox_manager/lib/SandboxManager/Controller/Sandboxes.pm
+++ b/sandbox_manager/lib/SandboxManager/Controller/Sandboxes.pm
@@ -66,6 +66,7 @@ sub create_submit {
     my $marc_flavour = $self->param('marc_flavour') || 'marc21';
     my $git_remote   = $self->param('git_remote');
     my $git_branch   = $self->param('git_branch');
+    my $git_commitid = $self->param('git_commitid');
 
     my $errors = {};
     $errors->{name_required}  = 1 unless $name;
@@ -100,6 +101,7 @@ sub create_submit {
                 KOHA_MARC_FLAVOUR => $marc_flavour,
                 GIT_REMOTE        => $git_remote,
                 GIT_BRANCH        => $git_branch,
+		GIT_COMMITID      => $git_commitid,
                 NOTES             => $notes,
                 DESCRIPTION       => $description,
                 PASSWORD          => $password,

--- a/sandbox_manager/templates/sandboxes/create_form.html.tt2
+++ b/sandbox_manager/templates/sandboxes/create_form.html.tt2
@@ -67,6 +67,9 @@
         <br/>
         <input type="text" class="form-control" name="git_branch" id="git_branch" aria-describedby="git_branchHelp" placeholder="Enter name of branch" value="[% params.git_branch | html %]">
         <small id="git_remoteHelp" class="form-text text-muted">Enter a Koha git remote address and branch here and it will be applied to your sandbox.</small>
+        <br/>
+        <input type="text" class="form-control" name="git_commitid" id="git_commitid" aria-describedby="git_commitidHelp" placeholder="Enter commit id or tag name">
+        <small id="git_commitidHelp" class="form-text text-muted">Or enter a commit id or a tag name to checkout.</small>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
This patch adds a new input on the sandbox creation view to provide a
commit id or a tag name to checkout.