### PR TITLE
Fix copy module parameter

### DIFF
--- a/ansible/setup-sandbox-server.yml
+++ b/ansible/setup-sandbox-server.yml
@@ -19,7 +19,7 @@
         mode: 365
         owner: root
         src: files/git/config
-        update: yes
+        force: yes
       notify:
         - "Update koha git repo"
     -


### PR DESCRIPTION
`update` is not a valid parameter for the `copy` module (used in the "**Install koha git config**" Ansible handler).

Use `force` instead.

This _should_ make `./setup-sandbox-server.sh` happy 😄

Fixes #41